### PR TITLE
fix: properly deref void** to void* for single task

### DIFF
--- a/util/dsa.c
+++ b/util/dsa.c
@@ -952,7 +952,7 @@ void buffer_is_zero_dsa_batch(struct buffer_zero_batch_task *batch_task,
 
     if (count == 1) {
         // DSA doesn't take batch operation with only 1 task.
-        result[0] = buffer_zero_dsa(buf, len);
+        result[0] = buffer_zero_dsa(buf[0], len);
     } else {
         assert(batch_task != NULL);
         buffer_zero_dsa_batch(batch_task, buf, count, len, result);


### PR DESCRIPTION
When submitting a single task using the batch task API, we have a bug where we run buffer_is_zero on the literal address of the buffer pointer, rather than on the actual buffer.